### PR TITLE
Fixes to SMURFA io and conversion

### DIFF
--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -22,7 +22,7 @@ class Entity(Representation, SmurfBase):
         assert world is not None
         self.model = _singular(model)
         self.origin = _singular(origin) if origin is not None else representation.Pose()
-        self._file = os.path.normpath(os.path.join(os.path.dirname(world.inputfile), file)) if not os.path.isabs(file) else file
+        self._file = os.path.normpath(os.path.join(os.path.dirname(world.inputfile), file)) if file and not os.path.isabs(file) else file
         if model is None and file is not None:
             if self._file.lower().rsplit(".", 1)[-1] in ["smurfs", "smurfa"]:
                 try:

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -351,6 +351,10 @@ class Arrangement(Representation, SmurfBase):
         assert outputfile.endswith("smurfa")
         self.inputfile = os.path.abspath(outputfile)
         out = self.to_yaml()
+        # Resolve entities
+        out['entities'] = []
+        for entity in self.entities:
+            out['entities'].append(entity.to_yaml())
         if not os.path.exists(os.path.dirname(os.path.abspath(outputfile))):
             os.makedirs(os.path.dirname(os.path.abspath(outputfile)), exist_ok=True)
         with open(outputfile, "w") as f:

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -187,6 +187,7 @@ class Arrangement(Representation, SmurfBase):
                 entity_defs = file_dict.get("entities", file_dict.get("smurfa", file_dict.get("smurfs", [])))
                 for e_def in entity_defs:
                     self.add_entity(Entity(world=self, **e_def))
+                self.name = file_dict.get('name')
             else:
                 raise IOError(f"The given file has an extension ({ext}) that cannot be parsed as Arrangement.")
         self.excludes += ["inputfile"]

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -275,6 +275,7 @@ class Arrangement(Representation, SmurfBase):
     def get_root_entities(self):
         return [e for e in self.entities if e._anchor in ["NONE", "WORLD"]]
 
+    # FIXME: This whole function does not work properly
     def assemble(self, root_entity=None):
         if root_entity is None:
             root_entities = self.get_root_entities()
@@ -285,8 +286,10 @@ class Arrangement(Representation, SmurfBase):
             assert root_entity is not None, f"No entity with name {root_entity} found."
 
         if isinstance(root_entity.model, Robot):
+            print(f"{root_entity.name} model {root_entity.model.name} is Robot")
             assembly = root_entity.model.duplicate()
         elif isinstance(root_entity.model, Arrangement):
+            print(f"{root_entity.name} model {root_entity.model.name} is Arrangement")
             assembly = root_entity.model.assemble()
         else:
             raise TypeError(f"Wrong model type of entity {root_entity.name}: {type(root_entity.model)}")

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -275,13 +275,6 @@ class Arrangement(Representation, SmurfBase):
     def get_root_entities(self):
         return [e for e in self.entities if e._anchor in ["NONE", "WORLD"]]
 
-    ###
-    # Current debugging state:
-    # The URDF link and joint structure is correct
-    # However, when exchange_root() is called
-    # - the visuals are distorted
-    # - and the transformations are not correct
-    ###
     def assemble(self, root_entity=None):
         if root_entity is None:
             root_entities = self.get_root_entities()
@@ -292,16 +285,13 @@ class Arrangement(Representation, SmurfBase):
             assert root_entity is not None, f"No entity with name {root_entity} found."
 
         if isinstance(root_entity.model, Robot):
-            print(f"{root_entity.name} model {root_entity.model.name} is Robot")
             assembly = root_entity.model.duplicate()
         elif isinstance(root_entity.model, Arrangement):
-            print(f"{root_entity.name} model {root_entity.model.name} is Arrangement")
             assembly = root_entity.model.assemble()
         else:
             raise TypeError(f"Wrong model type of entity {root_entity.name}: {type(root_entity.model)}")
         assembly.name = self.name
         assembly.unlink_from_world()
-        #assembly.rename_all(prefix=root_entity.name + "_" if self.name is None else self.name + "_" + root_entity.name + "_")
         assembly.rename_all(prefix=root_entity.name + "_")
         entities_in_tree = [root_entity]
 
@@ -330,8 +320,6 @@ class Arrangement(Representation, SmurfBase):
                     if entity.child is None or str(entity.child) == str(attach_model.get_root()):
                         child_link = attach_model.get_root()
                     else:
-                        # FIXME: exchange_root is buggy
-                        print(f"{attach_model.name}::{entity.child} becomes new root")
                         child_link = attach_model.get_link(entity.child)
                         # make sure that we have a consistent downward tree
                         attach_model.exchange_root(child_link)
@@ -339,7 +327,7 @@ class Arrangement(Representation, SmurfBase):
                     attach_model.rename_all(prefix=entity.name + "_", do_not_double=False)
                     origin = entity.origin.duplicate()
                     origin.relative_to = str(entity.origin.relative_to).replace("::", "_", 1)
-                    print(f"{child_link} -- {origin.position},{origin.quaternion_dict} -> {parent_link}")
+                    #print(f"{child_link} -- {origin.position},{origin.quaternion_dict} -> {parent_link}")
                     assembly.attach(
                         other=attach_model,
                         joint=representation.Joint(

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -332,7 +332,7 @@ class Arrangement(Representation, SmurfBase):
                     attach_model.rename_all(prefix=entity.name + "_", do_not_double=False)
                     origin = entity.origin.duplicate()
                     origin.relative_to = str(entity.origin.relative_to).replace("::", "_", 1)
-                    print(f"{child_link} -> {parent_link}")
+                    print(f"{child_link} -- {origin.position},{origin.quaternion_dict} -> {parent_link}")
                     assembly.attach(
                         other=attach_model,
                         joint=representation.Joint(

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -293,8 +293,10 @@ class Arrangement(Representation, SmurfBase):
             assembly = root_entity.model.assemble()
         else:
             raise TypeError(f"Wrong model type of entity {root_entity.name}: {type(root_entity.model)}")
+        assembly.name = self.name
         assembly.unlink_from_world()
-        assembly.rename_all(prefix=root_entity.name + "_" if self.name is None else self.name + "_" + root_entity.name + "_")
+        #assembly.rename_all(prefix=root_entity.name + "_" if self.name is None else self.name + "_" + root_entity.name + "_")
+        assembly.rename_all(prefix=root_entity.name + "_")
         entities_in_tree = [root_entity]
 
         attached = 1
@@ -311,7 +313,7 @@ class Arrangement(Representation, SmurfBase):
                     parent_entity, parent_link_name = entity._anchor.split("::", 1)
                 if parent_entity in [str(e) for e in entities_in_tree]:
                     parent_link = assembly.get_link(parent_entity+"_"+parent_link_name, verbose=True)
-                    assert parent_link is not None, f"parent link {parent_entity}_{parent_link_name} not found "+str(entity)
+                    assert parent_link is not None, f"parent link {parent_entity}::{parent_link_name} not found "+str(entity)
                     if isinstance(root_entity.model, Robot):
                         attach_model = entity.model.duplicate()
                         assembly.unlink_from_world()
@@ -322,6 +324,7 @@ class Arrangement(Representation, SmurfBase):
                     if entity.child is None or str(entity.child) == str(attach_model.get_root()):
                         child_link = attach_model.get_root()
                     else:
+                        print(f"{attach_model.name}::{entity.child} becomes new root")
                         child_link = attach_model.get_link(entity.child)
                         # make sure that we have a consistent downward tree
                         attach_model.exchange_root(child_link)
@@ -329,6 +332,7 @@ class Arrangement(Representation, SmurfBase):
                     attach_model.rename_all(prefix=entity.name + "_", do_not_double=False)
                     origin = entity.origin.duplicate()
                     origin.relative_to = str(entity.origin.relative_to).replace("::", "_", 1)
+                    print(f"{child_link} -> {parent_link}")
                     assembly.attach(
                         other=attach_model,
                         joint=representation.Joint(

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -74,7 +74,7 @@ class Entity(Representation, SmurfBase):
     @property
     def file(self):
         return os.path.relpath(
-            getattr(self.model, "smurffile", getattr(self.model, "xmlfile", getattr(self.model, "inputfile"))),
+            getattr(self.model, "smurffile", getattr(self.model, "xmlfile", getattr(self.model, "inputfiles"))),
             os.path.dirname(self.model._related_world_instance.inputfile)
         )
 

--- a/phobos/core/multiple.py
+++ b/phobos/core/multiple.py
@@ -275,7 +275,13 @@ class Arrangement(Representation, SmurfBase):
     def get_root_entities(self):
         return [e for e in self.entities if e._anchor in ["NONE", "WORLD"]]
 
-    # FIXME: This whole function does not work properly
+    ###
+    # Current debugging state:
+    # The URDF link and joint structure is correct
+    # However, when exchange_root() is called
+    # - the visuals are distorted
+    # - and the transformations are not correct
+    ###
     def assemble(self, root_entity=None):
         if root_entity is None:
             root_entities = self.get_root_entities()
@@ -324,6 +330,7 @@ class Arrangement(Representation, SmurfBase):
                     if entity.child is None or str(entity.child) == str(attach_model.get_root()):
                         child_link = attach_model.get_root()
                     else:
+                        # FIXME: exchange_root is buggy
                         print(f"{attach_model.name}::{entity.child} becomes new root")
                         child_link = attach_model.get_link(entity.child)
                         # make sure that we have a consistent downward tree

--- a/phobos/core/robot.py
+++ b/phobos/core/robot.py
@@ -971,6 +971,8 @@ class Robot(SMURFRobot):
             joint.parent = joint.child
             joint.child = _temp
             joint.origin = joint.origin.inv(joint.parent)
+            if joint.axis:
+                joint.axis = joint.origin.to_matrix()[0:3, 0:3].dot(joint.axis)
             joint.origin.link_with_robot(self)
         # 2. regenerate tree 
         # NOTE: This function updates the self.parent_map and self.child_map

--- a/phobos/core/robot.py
+++ b/phobos/core/robot.py
@@ -950,7 +950,6 @@ class Robot(SMURFRobot):
         #print(f"exchange_root: found chain between {str(self.get_root())} and {str(new_root)}: {[str(j) for j in flip_joints]}")
         old_robot = self.duplicate()
         or2x = lambda x: old_robot.get_transformation(x, start=str(old_robot.get_root()))
-        #nr2x = lambda x: old_robot.get_transformation(x, start=str(new_root))
         # Print out start origins
         for jl in self.links + self.joints:
             print(f"*** {str(jl)} ***")

--- a/phobos/core/robot.py
+++ b/phobos/core/robot.py
@@ -950,12 +950,6 @@ class Robot(SMURFRobot):
         #print(f"exchange_root: found chain between {str(self.get_root())} and {str(new_root)}: {[str(j) for j in flip_joints]}")
         old_robot = self.duplicate()
         or2x = lambda x: old_robot.get_transformation(x, start=str(old_robot.get_root()))
-        # Print out start origins
-        for jl in self.links + self.joints:
-            print(f"*** {str(jl)} ***")
-            if jl.origin is None:
-                continue
-            print(f"current origin: {jl.origin.position} {jl.origin.quaternion_dict} {str(jl.origin.relative_to)}")
         # 0. make sure all link parts follow the convention that they have to be relative_to that link
         for link in self.links:
             for vc in link.visuals + link.collisions + link.primitives:

--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -194,6 +194,8 @@ class Pose(Representation, SmurfBase):
             self._matrix[0:3, 3] = np.array([0.0, 0.0, 0.0])
         else:
             assert (type(value) in [list, np.ndarray, tuple] or (hasattr(value, "__len__") and type(value) != str)) and len(value) == 3
+            if isinstance(value, dict):
+                value = [value['x'], value['y'], value['z']]
             self._matrix[0:3, 3] = np.array(value)
 
     def from_vec(self, vec):

--- a/phobos/scripts/convert.py
+++ b/phobos/scripts/convert.py
@@ -66,7 +66,7 @@ def main(args):
     if len(output_split) < 1:
         log.error(f"Invalid output spec {args.output}")
         return 4
-    elif len(output_split) == 1:
+    elif len(output_split) == 1 or path.isdir(args.output):
         output_format = "DIRECTORY"
     elif output_split[-1] in ["smurfa"]:
         output_format = "SMURFA"

--- a/phobos/scripts/convert.py
+++ b/phobos/scripts/convert.py
@@ -108,7 +108,7 @@ def main(args):
         robot = Robot(inputfile=args.input)
 
     # Check results
-    if not world and not not robot:
+    if not world and not robot:
         log.error("You have specified something which could not be converted to neither a robot nor a world/arrangement")
         return 6
 

--- a/phobos/scripts/convert.py
+++ b/phobos/scripts/convert.py
@@ -79,7 +79,8 @@ def main(args):
     elif args.output.lower().endswith("smurf") or path.isdir(args.output):
         log.info("Converting to SMURF")
         if robot:
-            robot.export(outputdir=args.output, export_config=resources.get_default_export_config(), mesh_format=args.mesh_type)
+            #robot.export(outputdir=args.output, export_config=resources.get_default_export_config(), mesh_format=args.mesh_type)
+            robot.export(outputdir=args.output, export_config=resources.get_default_export_config())
         else: # todo this is also valid for sdf and urdf
             if not path.isdir(args.output):
                 raise IOError(f"Please specify a directory as output, when exporting a world with multiple entities. {args.output} is not a directory.")

--- a/phobos/scripts/convert.py
+++ b/phobos/scripts/convert.py
@@ -21,11 +21,8 @@ def main(args):
     from ..commandline_logging import setup_logger_level, BASE_LOG_LEVEL
 
     parser = argparse.ArgumentParser(description=INFO, prog="phobos " + path.basename(__file__)[:-3])
-    parser.add_argument('input', type=str, help='Path to the urdf or smurf file')
-    parser.add_argument('output', type=str, help='Writes the result to the given file. '
-                                                 'The output is determined by the file ending, '
-                                                 'if the output has no ending like sdf, urdf or pdf and '
-                                                 'is a (non-existing) directory SMURF will be exported.',
+    parser.add_argument('input', type=str, help='Input specification: A path to a file (with extension [smurfa, smurfs, smurf, urdf, sdf]) or directory')
+    parser.add_argument('output', type=str, help='Output specification: A path to a file (with extension [smurfa, smurfs, smurf, urdf, sdf]) or directory',
                         action="store", default=None)
     parser.add_argument('-c', '--copy-meshes', help='Copies the meshes', action='store_true', default=False)
     parser.add_argument('-m', '--mesh-type', choices=["stl", "obj", "mars_obj", "dae", "input_type"], help='If -c set the mesh type', default="input_type")
@@ -41,17 +38,79 @@ def main(args):
     if args.output.endswith("/"):
         args.output = args.output[:-1]
 
+    # Detect input format
+    input_format = None
+    input_split = args.input.lower().rsplit(".",1)
+    if len(input_split) < 1:
+        log.error(f"Invalid input spec {args.input}")
+        return 2
+    elif len(input_split) == 1:
+        input_format = "DIRECTORY"
+    elif input_split[-1] in ["smurfa"]:
+        input_format = "SMURFA"
+    elif input_split[-1] in ["smurfs"]:
+        input_format = "SMURFS"
+    elif input_split[-1] in ["smurf"]:
+        input_format = "SMURF"
+    elif input_split[-1] in ["urdf"]:
+        input_format = "URDF"
+    elif input_split[-1] in ["sdf"]:
+        input_format = "SDF"
+    else:
+        log.error(f"Could not determine input format from {args.input}")
+        return 3
+
+    # Detect output format
+    output_format = None
+    output_split = args.output.lower().rsplit(".",1)
+    if len(output_split) < 1:
+        log.error(f"Invalid output spec {args.output}")
+        return 4
+    elif len(output_split) == 1:
+        output_format = "DIRECTORY"
+    elif output_split[-1] in ["smurfa"]:
+        output_format = "SMURFA"
+    elif output_split[-1] in ["smurfs"]:
+        output_format = "SMURFS"
+    elif output_split[-1] in ["smurf"]:
+        output_format = "SMURF"
+    elif output_split[-1] in ["urdf"]:
+        output_format = "URDF"
+    elif output_split[-1] in ["sdf"]:
+        output_format = "SDF"
+    elif output_split[-1] in ["pdf"]:
+        output_format = "PDF"
+    elif output_split[-1] in ["jpg"]:
+        output_format = "IMAGE"
+    elif output_split[-1] in ["png"]:
+        output_format = "IMAGE"
+    else:
+        log.error(f"Could not determine output format from {args.output}")
+        return 5
+
+    # Check if input/output format combination is valid and choose corresponding procedure
+    if input_format == output_format:
+        log.info(f"Input and output format are equal. Will do nothing :)")
+        return 0
+
+    # If input is either smurfa or smurfs we have to assemble a robot first
     world = None
     robot = None
-    if args.input.rsplit(".", 1)[-1] in ["smurfa", "smurfs"]:
+    if input_format in ["SMURFA", "SMURFS"]:
         world = World(inputfile=args.input)
         if world.is_empty():
-            log.error("Given file is empty!")
+            log.error("World/Arrangement is empty")
             return 1
-        if args.output.lower() not in ["smurfa", "smurfs"] and world.has_one_root():
+        if world.has_one_root():
+            log.info(f"Assembling robot from World/Arrangement")
             robot = world.assemble()
     else:
         robot = Robot(inputfile=args.input)
+
+    # Check results
+    if not world and not not robot:
+        log.error("You have specified something which could not be converted to neither a robot nor a world/arrangement")
+        return 6
 
     if args.copy_meshes and robot and not args.export_config:
         robot.export_meshes(path.join(path.dirname(args.output), "meshes"), format=args.mesh_type)
@@ -60,56 +119,71 @@ def main(args):
         with open(args.export_config, "r") as f:
             export_config = load_json(f.read())
         robot.export(args.output, export_config=export_config["export_config"], with_meshes=args.copy_meshes, no_smurf=["no_smurf"])
-    elif args.output.lower().endswith("sdf"):
+    elif output_format in ["URDF"]:
+        log.info("Converting to URDF")
+        if robot:
+            robot.export_urdf(outputfile=args.output, mesh_format=args.mesh_type)
+        else:
+            raise NotImplementedError("Cannot export an URDF from World/Arrangement which cannot be assembled")
+    elif output_format in ["SDF"]:
         if args.sdf_assemble:  # world
             log.info("Converting to SDF model")
             robot.export_sdf(outputfile=args.output, mesh_format=args.mesh_type)
         else:  # world
+            # FIXME: This is actually not implemented. Will raise an Exception
             log.info("Converting to SDF world")
             world.export_sdf(outputfile=args.output, mesh_format=args.mesh_type)
-    elif args.output.lower().endswith("urdf"):
-        log.info("Converting to URDF")
-        robot.export_urdf(outputfile=args.output, mesh_format=args.mesh_type)
-    elif args.output.lower().endswith("pdf"):
+    elif output_format in ["PDF"]:
         log.info("Converting to PDF")
         if robot:
             robot.export_pdf(outputfile=args.output)
         else:
             raise NotImplementedError("Can't yet create PDF for world representations")
-    elif args.output.lower().endswith("smurf") or path.isdir(args.output):
-        log.info("Converting to SMURF")
+    elif output_format in ["IMAGE"]:
+        log.info("Converting to thumbnail")
         if robot:
-            #robot.export(outputdir=args.output, export_config=resources.get_default_export_config(), mesh_format=args.mesh_type)
-            robot.export(outputdir=args.output, export_config=resources.get_default_export_config())
-        else: # todo this is also valid for sdf and urdf
-            if not path.isdir(args.output):
-                raise IOError(f"Please specify a directory as output, when exporting a world with multiple entities. {args.output} is not a directory.")
-            for root in world.get_root_entities():
-                robot = world.assemble(root)
-                robot.export(outputdir=path.join(args.output, f"root-{root.name}"), export_config=getattr(world, "export_config", resources.get_default_export_config()), mesh_format=args.mesh_type)
-    elif args.output.lower().endswith("jpg") or args.output.lower().endswith("png"):
-        if robot:
-            log.info("Creating thumbnail")
             size=512
-            im = misc.get_thumbnail(robot.xmlfile, icon_size=size)
+            robotfile = robot.smurffile
+            if not robotfile:
+                robotfile = robot.xmlfile
+            if not robotfile:
+                log.error("Robot does not have a compatible specification file for thumbnail creation")
+            im = misc.get_thumbnail(robotfile, icon_size=size)
             misc.make_icon(im, args.output, size=size)
         else:
             raise NotImplementedError("Can't yet export thumbnails for world representations")
-    elif args.output.lower().endswith("smurfs"):
+    elif output_format in ["SMURF"]:
+        log.info("Converting to SMURF file inside a smurf directory (the file might be named differently than specified!)")
+        if robot:
+            robot.export_smurf(outputfile=args.output, mesh_format=args.mesh_type)
+        else:
+            raise NotImplementedError("Cannot export a SMURF from World/Arrangement which cannot be assembled")
+    elif output_format in ["DIRECTORY"]:
+        log.info("Converting to directory (will export multiple subformats in the appropriate subdirs)")
+        if robot:
+            robot.export(outputdir=args.output, export_config=resources.get_default_export_config())
+        else:
+            for root in world.get_root_entities():
+                robot = world.assemble(root)
+                robot.export(outputdir=path.join(args.output, f"root-{root.name}"), export_config=getattr(world, "export_config", resources.get_default_export_config()))
+    elif output_format in ["SMURFA"]:
+        log.info("Converting to SMURF Arrangement")
         if robot:
             world = World()
             world.add_robot(name="robot", robot=robot, anchor="world")
-        world.export_smurfs(outputfile=args.output, mesh_format=args.mesh_type)
-    elif args.output.lower().endswith("smurfa"):
+        world.export_smurfa(outputfile=args.output)
+    elif output_format in ["SMURFS"]:
+        log.info("Converting to SMURF Scene")
         if robot:
             world = World()
             world.add_robot(name="robot", robot=robot, anchor="world")
-        world.export_smurfa(outputfile=args.output, mesh_format=args.mesh_type)
+        world.export_smurfs(outputfile=args.output)
     else:
-        log.error(f"Don't know which conversion to apply for {args.output}")
-        return 1
-    return 0
+        log.error(f"Unknown conversion operation from {args.input} {input_format} to {args.output} {output_format}")
+        return 7
 
+    log.info("Done")
+    return 0
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
## Description
The complete IO handling and processing of Arrangements is currently not working correctly.
A SMURFA needs to also export its entities to be reimportable and therefore processable by e.g.
`phobos/scripts/convert.py`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#367 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I am currently working on creating a SMURFA from a database backend.
Because the SMURFA handling is not working, the inner parts and assemblies are not correctly converted to a top-level model (aka SMURF)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
