### PR TITLE
Fix mesh collision created at world origin / material creation

### DIFF
--- a/phobos/blender/model/materials.py
+++ b/phobos/blender/model/materials.py
@@ -32,6 +32,8 @@ def createPhobosMaterials():
                 new_material.node_tree.nodes.remove(principled_bsdf)
             shader_node = new_material.node_tree.nodes.new('ShaderNodeEeveeSpecular')
             material_output = new_material.node_tree.nodes.get('Material Output')
+            if material_output is None:
+                material_output = new_material.node_tree.nodes.new("ShaderNodeOutputMaterial")
             new_material.node_tree.links.new(shader_node.outputs[0], material_output.inputs[0])
             shader_node.inputs['Base Color'].default_value = tuple(mat['diffuse'])
             new_material.show_transparent_back = False

--- a/phobos/blender/operators/editing.py
+++ b/phobos/blender/operators/editing.py
@@ -1336,13 +1336,14 @@ class CreateCollisionObjects(Operator):
                 )
                 ob = phobos2blender.createGeometry(collision, geomsrc="collision", linkobj=sUtils.getEffectiveParent(vis, include_hidden=True, ignore_selection=True))
             else:
+                global_location = vis.matrix_world.to_translation()
                 ob = bUtils.createPrimitive(
                     collname,
                     'cylinder',
                     (1., 1., 1.),
                     defs.layerTypes['collision'],
                     materialname,
-                    phobos_vis.origin.position,
+                    global_location,
                     phobos_vis.origin.rotation,
                     'collision'
                 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Creates mesh collision objects at the location of its visual. Currently they are created at the world origin.
Adds a material output to a new material in case it wasn't added by default.

## Related Issue
#375 
#377 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
