### PR TITLE
Fix export with mirrored objects

### DIFF
--- a/phobos/blender/io/blender2phobos.py
+++ b/phobos/blender/io/blender2phobos.py
@@ -119,7 +119,7 @@ def deriveGeometry(obj, duplicate_mesh=False, fast_init=True, **kwargs):
     elif gtype == 'mesh':
         blender_mesh = obj.data.copy() if duplicate_mesh else obj.data
         return representation.Mesh(
-            scale=list(obj.matrix_world.to_scale()),
+            scale=list(obj.scale),
             mesh=blender_mesh,
             meshname=blender_mesh.name,
             fast_init=fast_init

--- a/phobos/utils/transform.py
+++ b/phobos/utils/transform.py
@@ -49,10 +49,13 @@ def rpy_to_matrix(rpy):
 
 
 def matrix_to_rpy(R):
-    try:
-        angles = Rot.from_matrix(R).as_euler(EULER_CONVENTION)
-    except:
-        angles = Rot.from_dcm(R).as_euler(EULER_CONVENTION)
+    determinant = np.linalg.det(R)
+    if determinant < 0:  # This is a reflection matrix
+        scale = np.sign(np.diag(R))
+        scaling_matrix = np.diag(scale)
+        R = np.dot(R, np.linalg.inv(scaling_matrix))
+    angles = Rot.from_matrix(R).as_euler(EULER_CONVENTION)
+
     return order_angles(angles, EULER_CONVENTION, RPY_CONVENTION)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Export currently fails if an object is mirrored using a negative scale. This PR allows exporting mirrored objects

## Related Issue
#377 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
