### PR TITLE
Some fixes to pre_v2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ doc/_build
 *_wip**
 tests/api/test_data/.temp**
 *.zip
+*.code-workspace

--- a/phobos/blender/operators/editing.py
+++ b/phobos/blender/operators/editing.py
@@ -1061,11 +1061,25 @@ class GenerateInertialObjectsOperator(Operator):
         description="Clear existing inertial objects of selected links.",
     )
 
+    _toggling : BoolProperty(
+        name="Ensure no infinite recursion when toggling visuals and collisions",
+        default=False,
+        description="Used to avoid infine recursion when toggling visuals/collisions",
+    )
+
     def toggleVisual(self, context):
+        if self._toggling:
+            return
+        self._toggling = True
         self.collisions = not bool(self.visuals)
+        self._toggling = False
 
     def toggleCollision(self, context):
+        if self._toggling:
+            return
+        self._toggling = True
         self.visuals = not bool(self.collisions)
+        self._toggling = False
 
     visuals : BoolProperty(
         name="visual",

--- a/phobos/blender/utils/blender.py
+++ b/phobos/blender/utils/blender.py
@@ -62,6 +62,36 @@ def getBlenderVersion():
     return bpy.app.version[0] * 100 + bpy.app.version[1]
 
 
+def blenderVersionIsAtLeast(required_version: tuple) -> bool:
+    """
+    Check if the current Blender version is greater than or equal to a given version.
+
+    Args:
+        required_version (tuple): Version you want to check against.
+                                  Example: (4, 0) or (3, 6, 2)
+
+    Returns:
+        bool: True if the current Blender version >= required_version, False otherwise.
+    """
+    current_version = bpy.app.version
+
+    for blender_v, required_v in zip(current_version, required_version):
+        if blender_v > required_v:
+            log(f"Current version {current_version} > {required_version}", "DEBUG")
+            return True
+        if blender_v < required_v:
+            log(f"Current version {current_version} < {required_version}", "DEBUG")
+            return False
+
+    # If we get here, all compared numbers are equal
+    if len(current_version) >= len(required_version):
+        log(f"Current version {current_version} >= {required_version}", "DEBUG")
+        return True  # current_version is equal or has more patch info
+    else:
+        log(f"Could not parse version provided to blenderVersionIsAtLeast: {required_version}", "ERROR")
+        return False
+
+
 def getPhobosPreferences():
     """TODO Missing documentation"""
     return bpy.context.preferences.addons["phobos"].preferences

--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -1072,12 +1072,9 @@ class Mesh(Representation, SmurfBase):
                     path_mode_relative = "RELATIVE"
                 if b41Export:
                     # Adapt axis forward and UP to match the expected values
-                    axis_forward = "NEGATIVE_X" if axis_forward == "-X" else axis_forward
-                    axis_forward = "NEGATIVE_Y" if axis_forward == "-Y" else axis_forward
-                    axis_forward = "NEGATIVE_Z" if axis_forward == "-Z" else axis_forward
-                    axis_up = "NEGATIVE_X" if axis_up == "-X" else axis_up
-                    axis_up = "NEGATIVE_Y" if axis_up == "-Y" else axis_up
-                    axis_up = "NEGATIVE_Z" if axis_up == "-Z" else axis_up
+                    # E.g. "-X" becomes "NEGATIVE_X"
+                    axis_forward = axis_forward.replace("-", "NEGATIVE_")
+                    axis_up = axis_up.replace("-", "NEGATIVE_")
                     bpy.ops.wm.obj_export(
                         filepath=targetpath,
                         export_selected_objects=True,

--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -1029,7 +1029,7 @@ class Mesh(Representation, SmurfBase):
             else:
                 log.warn(f"Couldn't provide mesh {self.unique_name} to {targetpath}, because this mesh can't be exported as bobj")
             return
-        elif format.lower() == "bobj" and (not self._info_in_sync and "texture_coords" in self._mesh_information):
+        elif format.lower() == "bobj" and (not self._info_in_sync and self._mesh_information is not None and "texture_coords" in self._mesh_information):
             if throw_on_invalid_bobj:
                 raise IOError(
                     f"Couldn't provide mesh {self.unique_name} to {targetpath}, because this mesh has been edited and thus the textures might have get mixed up.")

--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -1066,6 +1066,10 @@ class Mesh(Representation, SmurfBase):
                 axis_up = bpy.context.preferences.addons["phobos"].preferences.obj_axis_up
                 # If user wants to export texture, we also export .mtl file associated to the .obj file
                 export_texture = bpy.context.scene.phobosexportsettings.exportTextures
+                # Adapt export path type for the .mtl files to also use relative path
+                path_mode_relative = "AUTO"
+                if "relative" in getattr(bpy.context.scene.phobosexportsettings, "urdfOutputPathtype"):
+                    path_mode_relative = "RELATIVE"
                 if b41Export:
                     bpy.ops.wm.obj_export(
                         filepath=targetpath,
@@ -1075,6 +1079,7 @@ class Mesh(Representation, SmurfBase):
                         apply_modifiers=True,
                         forward_axis=axis_forward,
                         up_axis=axis_up,
+                        path_mode=path_mode_relative,
                     )
                 else:
                     bpy.ops.export_scene.obj(
@@ -1086,6 +1091,7 @@ class Mesh(Representation, SmurfBase):
                         use_blen_objects=False,
                         axis_forward=axis_forward,
                         axis_up=axis_up,
+                        path_mode=path_mode_relative,
                     )
             elif format.lower() == 'stl':
                 if b41Export:

--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -1071,6 +1071,13 @@ class Mesh(Representation, SmurfBase):
                 if "relative" in getattr(bpy.context.scene.phobosexportsettings, "urdfOutputPathtype"):
                     path_mode_relative = "RELATIVE"
                 if b41Export:
+                    # Adapt axis forward and UP to match the expected values
+                    axis_forward = "NEGATIVE_X" if axis_forward == "-X" else axis_forward
+                    axis_forward = "NEGATIVE_Y" if axis_forward == "-Y" else axis_forward
+                    axis_forward = "NEGATIVE_Z" if axis_forward == "-Z" else axis_forward
+                    axis_up = "NEGATIVE_X" if axis_up == "-X" else axis_up
+                    axis_up = "NEGATIVE_Y" if axis_up == "-Y" else axis_up
+                    axis_up = "NEGATIVE_Z" if axis_up == "-Z" else axis_up
                     bpy.ops.wm.obj_export(
                         filepath=targetpath,
                         export_selected_objects=True,


### PR DESCRIPTION
Edit: I can't assign any reviewer, but I suppose good reviewers here would be @hwiedPro or @AlpenAalAlex since they are working on the target branch.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Hello, I fixed some stuff that was not working for me and propose these changes, that you can approve or reject if you are already working on another way to solves these issues.

I am using Flatpack Blender version 4.5.2

Here is a list of the issues that I fixed

# Issue 1: Click on "Create Inertials" button makes Blender crash

Given a well formed model with links, collisions, visuals, root, names etc, when I selected any part of the model and clicked on "Create Inertials", my blender crashed. After checking the logs, it seems that it is due to a infinite recursion for [toggleVisuals and toggleCollisions](https://github.com/dfki-ric/phobos/compare/pre_v2.1.0...PimpMyPizza:phobos:pre_v2.1.0#diff-23a14533d225ca7065719c761e33d7c764993c3dd1147ac8d9cb22de38a12220R1064-R1082). Note that I'm not quite sure why the code says `self.collisions = not bool(self.visuals)` instead of `self.collisions = not bool(self.collisions)` but I did not change it.

# Issue 2: export of .bobj files did not work

I could not export .bobj meshes because of a logic error [in phobos/io/representation.py line 1033](https://github.com/dfki-ric/phobos/compare/pre_v2.1.0...PimpMyPizza:phobos:pre_v2.1.0#diff-bce5d2d9782ea1c8b2cd960545690c0014c51bfab3eeb795e53c183b6b400976R1033).
In the first `if not BPY_AVAILABLE and format.lower() == "bobj" and self._mesh_information is None`, if `BPY_AVAILABLE` is `True` and `self._mesh_information` is `None`, the `elif` statement is checked, but it then throw an error because `self._mesh_information` is `None` and `"texture_coords" in self._mesh_information` therefore fails.

# Issue 3: Export fails when the axis forward and axis up are negative in the phobos settings

I adapted [these lines](https://github.com/dfki-ric/phobos/pull/392/files#diff-bce5d2d9782ea1c8b2cd960545690c0014c51bfab3eeb795e53c183b6b400976R1076-R1077) because the string value for the axis does not match the ones expected in [the API](https://docs.blender.org/api/current/bpy.ops.wm.html#bpy.ops.wm.obj_export)

# Issue 4: When exporting with .obj meshes, the .mtl are missing

Since I have extra textures with images and stuff, I need to export as .obj with the according .mtl. So I adapted the code so that, if the "Export Textures" checkbox is checked and the export is done for .obj meshes, then the .mtl file is also exported. This is the change in [this line](https://github.com/dfki-ric/phobos/compare/pre_v2.1.0...PimpMyPizza:phobos:pre_v2.1.0#diff-bce5d2d9782ea1c8b2cd960545690c0014c51bfab3eeb795e53c183b6b400976R1068)

# Issue 5: When exporting .obj meshes, the .mtl file has absolute/auto path.

After making the changes for issues 4, I also added the code so that the path in the .mtl files are relative if the export path type contains the string "relative", e.g. "relative + ros_package". The changes are [here](https://github.com/dfki-ric/phobos/compare/pre_v2.1.0...PimpMyPizza:phobos:pre_v2.1.0#diff-bce5d2d9782ea1c8b2cd960545690c0014c51bfab3eeb795e53c183b6b400976R1070-R1072)

# Additional change

I created the function `blenderVersionIsAtLeast` in order to avoid duplicate code when comparing versions

# 

## Related Issue

Since it's a PR for 4/5 issues that don't exist, I created this PR directly and described the issues I had. If needed, I can create new issues if required

## Motivation and Context
I am using phobos for urdf export of plants and robot for Isaac-Sim and I ran into these issues

## How Has This Been Tested?

I have tested these changes by me locally, but I did not write any unit tests or so
I am in Linux 24.04 and I use The Flatpak Blender version 4.5.2

## Screenshots (if appropriate):
These were my export settings
<img width="728" height="1080" alt="image" src="https://github.com/user-attachments/assets/6ed760da-007d-42ff-9011-3b4c90bc7137" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
