### PR TITLE
When importing blenderVersionIsAtLeast or other bpy dependent stuff guard it properly

### DIFF
--- a/phobos/io/representation.py
+++ b/phobos/io/representation.py
@@ -21,11 +21,11 @@ from ..utils import misc, git, transform
 from ..utils.transform import inv
 from ..utils.xml import read_relative_filename
 from .. import defs as phobos_defs
-from ..blender.utils.blender import blenderVersionIsAtLeast
 
 MESH_INFO_KEYS = ["vertex_normals", "texture_coords", "vertices", "faces"]
 MESH_DATA_TYPES = ["trimesh.base.Trimesh", "trimesh.scene.scene.Scene", "file_obj", "file_stl", "file_dae", "file_iv"]
 if BPY_AVAILABLE:
+    from ..blender.utils.blender import blenderVersionIsAtLeast
     import bpy
 
     def _bpy_mesh_dc(inst, memo={}):
@@ -1052,8 +1052,8 @@ class Mesh(Representation, SmurfBase):
             return
         # export for blender
         # A new file handler API was introduced in Blender 4.1
-        b41Export = blenderVersionIsAtLeast((4,1))
         if BPY_AVAILABLE and isinstance(self.mesh_object, bpy.types.Mesh):
+            b41Export = blenderVersionIsAtLeast((4,1))
             from ..blender.utils import blender as bUtils
             objname = "tmp_export_"+self.unique_name
             tmpobject = bUtils.createPrimitive(objname, 'box', (1.0, 1.0, 1.0))


### PR DESCRIPTION
I've had the problem that when i was using standalone phobos (without blender) by e.g.
`from phobos.core import Robot`
that i got the following error chain:

```
phobos/__init__.py", line 262, in <module>
    from . import io
  File ".../phobos/io/__init__.py", line 1, in <module>
    from . import representation
  File ".../phobos/io/representation.py", line 24, in <module>
    from ..blender.utils.blender import blenderVersionIsAtLeast
  File ".../phobos/blender/utils/blender.py", line 18, in <module>
    import bpy
ModuleNotFoundError: No module named 'bpy'
```

These changes fix that issue by guarding some unguarded calls to `bpy` behind a check of `BPY_AVAILABLE`.