### PR TITLE
Fix bones when importing joints

### DIFF
--- a/phobos/blender/model/joints.py
+++ b/phobos/blender/model/joints.py
@@ -201,12 +201,25 @@ def setJointConstraints(
         applySpringDamping(joint)
 
     # set constraints accordingly
+    if lower is None:
+        lower = 0.0
+    if upper is None:
+        upper = 0.0
+    if lower2 is None:
+        lower2 = 0.0
+    if upper2 is None:
+        upper2 = 0.0
     joint['joint/limits/lower'] = lower
     joint['joint/limits/upper'] = upper
     joint['joint/limits/lower2'] = lower2
     joint['joint/limits/upper2'] = upper2
     joint.data.bones.active = joint.pose.bones[0].bone
-    joint.data.bones.active.select = True
+
+    bpy.ops.object.mode_set(mode='EDIT')
+    eb = joint.data.edit_bones[0]
+    eb.select = True
+    bpy.ops.object.mode_set(mode='POSE')
+
     remove_screwdrivers(joint)
 
     if jointtype == 'revolute':


### PR DESCRIPTION
switch to edit mode for selecting the bone, assure lower/upper are at least numbers

## Description
This fixes the import of URDFs without defined bones (like our Lunis from the SAMLER-KI research project)

## Related Issue
No issue was created, the pr is directly fixing this new issue

## Motivation and Context
see description

## How Has This Been Tested?
The bugfix has been tested with the Lunis Rover, however it was not checked for other issues

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
